### PR TITLE
Full width for Goatim thumbnail

### DIFF
--- a/src/soccer/matches/matchThumbnail.scss
+++ b/src/soccer/matches/matchThumbnail.scss
@@ -3,6 +3,7 @@
 
 .goatim-ui-match-thumbnail {
   display: inline-block;
+  width: 100%;
   background: white;
   border-radius: 20px;
   padding: 20px 10px;
@@ -27,7 +28,7 @@
   > .tags {
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: center;
     margin-top: 15px;
   }
 


### PR DESCRIPTION
**Before**:
<img width="415" alt="image" src="https://github.com/goatim/ui/assets/4073197/af6d0937-ec3d-4023-990d-b06d81fe19d1">

**After**:
<img width="367" alt="image" src="https://github.com/goatim/ui/assets/4073197/d280ac2c-f166-418b-bac4-2de7e8b026b1">
